### PR TITLE
Fix key attribute of list elements not accounting for deleted entries

### DIFF
--- a/lib/ListExtender.js
+++ b/lib/ListExtender.js
@@ -233,6 +233,9 @@
       if (canRemove(input.target, thing) && thing.listSize > 1) {
         thing.element.removeChild(input.target.parentElement);
         thing.listSize--;
+        thing.element.childNodes.forEach((e, index) => {
+          e.setAttribute("key", index + 1);
+        });
       } else if (validate(input.target) && customChecks(input.target, thing)) {
         turnToList(input.target, thing);
       }


### PR DESCRIPTION
Pull request for #16.

This fix loops through the updated ul to reassign keys to reflect the deletion of an entry.